### PR TITLE
fix: 三项bug修复 — 无限循环 + title丢失 + Q&A漏判

### DIFF
--- a/.github/workflows/org-router.yml
+++ b/.github/workflows/org-router.yml
@@ -43,13 +43,10 @@ on:
 
 jobs:
   route:
-    # Bot 自身评论不触发，防止无限循环（仅对 discussion_comment 事件）
+    # Bot 自身评论不触发，防止无限循环（已证 nevstop 非 Bot 类型，仅靠 marker 判断）
     if: |
       github.event_name != 'discussion_comment' ||
-      !(
-        contains(github.event.comment.body, '<!-- csm-qa-bot -->') &&
-        github.event.comment.user.type == 'Bot'
-      )
+      !contains(github.event.comment.body, '<!-- csm-qa-bot -->')
     runs-on: ubuntu-latest
     concurrency:
       group: org-router-${{ github.event.client_payload.discussion_number || github.event.discussion.number || github.event.inputs.discussion_number }}
@@ -108,6 +105,7 @@ jobs:
           JOIN_STAR_REPOS: ${{ vars.JOIN_STAR_REPOS || 'csm-core,API String,MassData,INIVariable' }}
           ROUTER_DISCUSSION_NUMBER: ${{ github.event.client_payload.discussion_number || github.event.discussion.number || github.event.inputs.discussion_number }}
           ROUTER_COMMENT_BODY: ${{ github.event.client_payload.comment_body || github.event.comment.body || github.event.discussion.body || github.event.inputs.comment_body || '' }}
+          ROUTER_DISCUSSION_TITLE: ${{ github.event.discussion.title || '' }}
           ROUTER_COMMENT_AUTHOR: ${{ github.event.client_payload.comment_author || github.event.comment.user.login || github.event.discussion.user.login || github.event.inputs.comment_author || '' }}
           ROUTER_CATEGORY_NAME: ${{ github.event.client_payload.category_name || github.event.discussion.category.name || github.event.inputs.category_name || '' }}
           ROUTER_EVENT_TYPE: ${{ github.event.client_payload.event_type || github.event_name || '' }}
@@ -115,6 +113,7 @@ jobs:
           python scripts/router.py \
             --discussion-number "${ROUTER_DISCUSSION_NUMBER}" \
             --comment-body "${ROUTER_COMMENT_BODY}" \
+            --discussion-title "${ROUTER_DISCUSSION_TITLE}" \
             --comment-author "${ROUTER_COMMENT_AUTHOR}" \
             --category-name "${ROUTER_CATEGORY_NAME}" \
             --event-type "${ROUTER_EVENT_TYPE}" \

--- a/scripts/router.py
+++ b/scripts/router.py
@@ -649,6 +649,12 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         help="评论正文（Webhook 传入，最大 800 字符）",
     )
     parser.add_argument(
+        "--discussion-title",
+        type=str,
+        default="",
+        help="Discussion 标题（discussion 事件时用于拼接分类输入）",
+    )
+    parser.add_argument(
         "--comment-author",
         type=str,
         default="",
@@ -692,17 +698,31 @@ def main(argv: Optional[list[str]] = None) -> int:
         args.dry_run,
     )
 
-    # 1. LLM 意图分类
-    intent = classify_intent(args.comment_body)
+    # 1. 构造分类输入：discussion 事件将标题拼入正文（标题承载主要意图）
+    classify_input = args.comment_body
+    if args.event_type == "discussion" and args.discussion_title.strip():
+        classify_input = f"{args.discussion_title.strip()}\n\n{args.comment_body}".strip()
+
+    intent = classify_intent(classify_input)
     logger.info("意图分类: %s", intent)
 
-    # 1b. 空评论的特殊处理：discussion.created 事件无评论、但标题/正文可能是 QA
-    if not args.comment_body.strip() and args.event_type == "discussion":
+    # 1b. Q&A 分类的 discussion.created：正文短 → 直接按 QA 处理
+    if (
+        args.event_type == "discussion"
+        and intent == "OTHER"
+        and args.category_name == QA_CATEGORY_NAME
+        and len(args.comment_body.strip()) <= 20
+    ):
+        logger.info("短正文 + Q&A 分类 + discussion.created → 按 QA 处理")
+        intent = "QA"
+
+    # 1c. 空评论的特殊处理：discussion.created 事件无评论、但正文可能是 QA
+    if not classify_input.strip() and args.event_type == "discussion":
         if args.category_name == QA_CATEGORY_NAME:
-            logger.info("空评论 + Q&A 分类 + discussion.created → 按 QA 处理")
+            logger.info("空内容 + Q&A 分类 + discussion.created → 按 QA 处理")
             intent = "QA"
         else:
-            logger.info("空评论 + 非 Q&A + discussion.created → 跳过（不回复）")
+            logger.info("空内容 + 非 Q&A + discussion.created → 跳过（不回复）")
             return 0
 
     # 2. 按意图分派


### PR DESCRIPTION
1. bot filter: 移除无效的 user.type=='Bot' 检查（nevstop 是 User 类型）， 仅靠 marker 判断即可阻断无限循环。
2. discussion 事件: 将 title 拼入 classify_input， LLM 可看到完整意图（'申请加入组织'而非仅 'xx'）。
3. Q&A discussion: 正文≤20字符且 LLM 返回 OTHER 时， 若分类为 Q&A 则直接按 QA 处理（兜底 '如题' 等短正文）。