### PR TITLE
fix: HTTPError 是 URLError 子类，404 被误转为 RuntimeError

### DIFF
--- a/scripts/router.py
+++ b/scripts/router.py
@@ -150,6 +150,8 @@ def _rest_req(token: str, method: str, path: str) -> Any:
     )
     try:
         return urllib.request.urlopen(req, timeout=15)
+    except urllib.error.HTTPError:
+        raise  # 4xx/5xx 原样抛出，由 _check_* 解析 404 语义
     except urllib.error.URLError as exc:
         raise RuntimeError(f"REST 请求失败 {method} {path}: {exc}") from exc
 


### PR DESCRIPTION
urllib.error.HTTPError 继承自 URLError，_rest_req 中的 except URLError 把 _check_star/_check_following 依赖的 404 语义全部吞掉。
改为 HTTPError 原样抛出，仅对真正的网络错误（DNS/超时）转 RuntimeError。 同时修复 _check_following 的相同隐患。