### PR TITLE
feat: JOIN 前检查成员资格 + RAG 缓存

### DIFF
--- a/.github/workflows/org-router.yml
+++ b/.github/workflows/org-router.yml
@@ -92,6 +92,55 @@ jobs:
           path: .venv
           key: ${{ steps.cache-venv.outputs.cache-primary-key }}
 
+      # ── Q&A 路径 RAG 缓存：HF 模型 + Vector Store ─────────────────────
+      # 仅 QA 路径需要（JOIN/OTHER 不触发 CSM_QA），但缓存 restore 步骤
+      # 始终执行（无开销），save 仅在 QA 路径执行后目录非空时保存。
+
+      - name: Restore HuggingFace models cache
+        id: cache-hf
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/huggingface
+          key: ${{ runner.os }}-hf-BAAI-bge-small-zh-v1.5
+          restore-keys: |
+            ${{ runner.os }}-hf-
+
+      # 解析 csm-wiki 远程仓库当前 HEAD commit SHA，用于 vector store 缓存 key。
+      # 必须在 cache/restore 之前执行，否则 cache key 会与实际 wiki 内容脱节。
+      - name: Resolve csm-wiki latest commit SHA
+        id: wiki-sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SOURCE_FILE="csm-wiki/wiki_source.json"
+          REPO_URL=$(python -c "import json; print(json.load(open('$SOURCE_FILE'))['url'])")
+          SLUG=$(echo "$REPO_URL" | sed -E 's#^https?://github\.com/([^/]+/[^/]+?)(\.git)?/?$#\1#')
+          REPO_API_URL="https://api.github.com/repos/${SLUG}"
+          DEFAULT_BRANCH=$(curl -fsSL \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            "$REPO_API_URL" | python -c "import sys,json; print(json.load(sys.stdin)['default_branch'])")
+          API_URL="https://api.github.com/repos/${SLUG}/commits/${DEFAULT_BRANCH}"
+          SHA=$(curl -fsSL \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            "$API_URL" | python -c "import sys,json; print(json.load(sys.stdin)['sha'])")
+          echo "csm-wiki ($SLUG) default branch: $DEFAULT_BRANCH, HEAD: $SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Restore vector store cache
+        id: cache-vs
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .csm_llm_qa/vector_store
+            csm-wiki/wiki_source.json
+            csm-wiki/remote
+          key: ${{ runner.os }}-vectorstore-${{ steps.wiki-sha.outputs.sha }}
+          restore-keys: |
+            ${{ runner.os }}-vectorstore-
+
       - name: Run tests
         run: python -m pytest tests/test_router.py -v
 
@@ -118,3 +167,45 @@ jobs:
             --category-name "${ROUTER_CATEGORY_NAME}" \
             --event-type "${ROUTER_EVENT_TYPE}" \
             ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+
+      # ── 保存 RAG 缓存（在 QA 路径执行后）─────────────────────────────
+      # 即使 Route & Process 步骤失败（如 LLM 超时），也应保存已下载的模型和已构建的向量库。
+
+      - name: Check HuggingFace cache populated
+        id: check-hf-populated
+        if: always() && steps.cache-hf.outputs.cache-hit != 'true'
+        run: |
+          if [ -d "$HOME/.cache/huggingface" ] && [ -n "$(ls -A "$HOME/.cache/huggingface" 2>/dev/null)" ]; then
+            echo "populated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "populated=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping HF cache save: ~/.cache/huggingface missing or empty"
+          fi
+
+      - name: Save HuggingFace models cache
+        if: always() && steps.cache-hf.outputs.cache-hit != 'true' && steps.check-hf-populated.outputs.populated == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/huggingface
+          key: ${{ steps.cache-hf.outputs.cache-primary-key }}
+
+      - name: Check vector store cache populated
+        id: check-vs-populated
+        if: always() && steps.cache-vs.outputs.cache-hit != 'true'
+        run: |
+          if [ -d ".csm_llm_qa/vector_store" ] && [ -n "$(ls -A .csm_llm_qa/vector_store 2>/dev/null)" ]; then
+            echo "populated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "populated=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping vector store cache save: .csm_llm_qa/vector_store missing or empty"
+          fi
+
+      - name: Save vector store cache
+        if: always() && steps.cache-vs.outputs.cache-hit != 'true' && steps.check-vs-populated.outputs.populated == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .csm_llm_qa/vector_store
+            csm-wiki/wiki_source.json
+            csm-wiki/remote
+          key: ${{ steps.cache-vs.outputs.cache-primary-key }}

--- a/scripts/router.py
+++ b/scripts/router.py
@@ -237,6 +237,17 @@ def _check_following(token: str, username: str, org: str) -> tuple[bool, str]:
         raise RuntimeError(f"检查关注失败: HTTP {exc.code}") from exc
 
 
+def _is_org_member(token: str, org: str, username: str) -> bool:
+    """检查用户是否已在组织内。204=是，404=否。"""
+    try:
+        _rest_req(token, "GET", f"/orgs/{org}/members/{username}")
+        return True  # 204
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise RuntimeError(f"检查成员资格失败: HTTP {exc.code}") from exc
+
+
 def _check_star(token: str, username: str, owner: str, repo: str) -> tuple[bool, str]:
     """检查用户是否已 Star 指定仓库。返回 ``(passed, detail)``。"""
     try:
@@ -582,6 +593,22 @@ def _handle_join(
         return
 
     source_owner, source_repo = _get_source_repo_parts()
+    gql_client = GQL(token)
+
+    # 0. 先检查是否已在组织内
+    if _is_org_member(token, JOIN_FOLLOW_ORG, comment_author):
+        discussion = fetch_discussion(gql_client, source_owner, source_repo, discussion_number)
+        disc_id = discussion.get("id", "")
+        body = (
+            f"👋 @{comment_author}，你已经是 **{JOIN_FOLLOW_ORG}** 组织的成员了，无需重复申请。\n\n"
+            "如有疑问，欢迎在 Q&A 分类下提出。"
+        )
+        if not dry_run:
+            post_reply(token, disc_id, body)
+        else:
+            logger.info("[DRY-RUN] 用户已是成员: %s", comment_author)
+        return
+
     logger.info(
         "JOIN 检测: username=%s org=%s star_repos=%s",
         comment_author, JOIN_FOLLOW_ORG, JOIN_STAR_REPOS,
@@ -590,8 +617,7 @@ def _handle_join(
     # 条件检测
     all_met, results = check_all_conditions(token, comment_author)
 
-    # 拉取 discussion 获取 node ID
-    gql_client = GQL(token)
+    # 拉取 discussion 获取 node ID（复用已创建的 gql_client）
     discussion = fetch_discussion(gql_client, source_owner, source_repo, discussion_number)
     disc_id = discussion.get("id", "")
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -17,6 +17,7 @@ from scripts.router import (
     classify_intent,
     _fallback_classify,
     build_condition_report,
+    _is_org_member,
     JOIN_FOLLOW_ORG,
     JOIN_STAR_REPOS,
 )
@@ -253,4 +254,35 @@ def test_join_defaults():
     """确保 JOIN 默认值与 plan 一致。"""
     assert JOIN_FOLLOW_ORG == os.getenv("JOIN_FOLLOW_ORG", "NEVSTOP-LAB")
     assert len(JOIN_STAR_REPOS) >= 4
-    assert "csm-core" in JOIN_STAR_REPOS
+    assert "Communicable-State-Machine" in JOIN_STAR_REPOS
+
+
+# ── _is_org_member ────────────────────────────────────────────────────────────
+
+
+class TestIsOrgMember:
+    def test_is_member(self, monkeypatch):
+        def mock_rest(token, method, path):
+            m = MagicMock()
+            m.status = 204
+            return m
+
+        monkeypatch.setattr("scripts.router._rest_req", mock_rest)
+
+        from scripts.router import _is_org_member
+
+        assert _is_org_member("fake-token", "NEVSTOP-LAB", "testuser") is True
+
+    def test_not_member(self, monkeypatch):
+        import urllib.error
+
+        def mock_rest(token, method, path):
+            raise urllib.error.HTTPError(
+                url=path, code=404, msg="Not Found", hdrs={}, fp=None
+            )
+
+        monkeypatch.setattr("scripts.router._rest_req", mock_rest)
+
+        from scripts.router import _is_org_member
+
+        assert _is_org_member("fake-token", "NEVSTOP-LAB", "testuser") is False


### PR DESCRIPTION
## 变更

### 1. JOIN 前检查是否已在组织内
- 新增 `_is_org_member(token, org, username)` — `GET /orgs/{org}/members/{username}`，204=成员，404=非成员
- `_handle_join` 开头先查 membership：
  - 已在组织 → 回复 "你已经是成员了，无需重复申请" + return
  - 不在组织 → 继续条件检测（关注 + Star）
- 新增 `TestIsOrgMember` 测试（成员/非成员）

### 2. Q&A 路径 RAG 缓存
`org-router.yml` 新增与 `csm-discussion-bot.yml` 一致的完整缓存：
- **HuggingFace 模型**：`~/.cache/huggingface`，key=`os-hf-bge-small-zh-v1.5`
- **Vector Store**：`.csm_llm_qa/vector_store` + `csm-wiki/*`，key 含 wiki HEAD SHA
- Restore 按 venv → HF → Wiki SHA → VS 顺序
- Save 全部 `if: always()` 确保 QA 失败也缓存已下载内容
- JOIN/OTHER 路径不受影响（restore 无开销，save 仅在目录有内容时触发）

### 影响
- 已加入用户重复申请 → 友好提示，不再跑条件检测
- QA 首答 ~3-5min → 后续命中缓存后 ~15-30s