### PR TITLE
fix: 降级正则强弱分层 + workflow 按意图分支化

### DIFF
--- a/.github/workflows/org-router.yml
+++ b/.github/workflows/org-router.yml
@@ -43,7 +43,7 @@ on:
 
 jobs:
   route:
-    # Bot 自身评论不触发，防止无限循环（已证 nevstop 非 Bot 类型，仅靠 marker 判断）
+    # Bot 自身评论不触发，防止无限循环（仅靠 marker 判断）
     if: |
       github.event_name != 'discussion_comment' ||
       !contains(github.event.comment.body, '<!-- csm-qa-bot -->')
@@ -55,6 +55,8 @@ jobs:
       contents: read
       discussions: write
     steps:
+      # ── 基础环境 ──────────────────────────────────────────────────────
+
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.CSM_QA_GH_TOKEN }}
@@ -92,12 +94,62 @@ jobs:
           path: .venv
           key: ${{ steps.cache-venv.outputs.cache-primary-key }}
 
-      # ── Q&A 路径 RAG 缓存：HF 模型 + Vector Store ─────────────────────
-      # 仅 QA 路径需要（JOIN/OTHER 不触发 CSM_QA），但缓存 restore 步骤
-      # 始终执行（无开销），save 仅在 QA 路径执行后目录非空时保存。
+      - name: Run tests
+        run: python -m pytest tests/test_router.py -v
+
+      # ── LLM 分类：轻量，仅 LLM 调用 / 正则 ───────────────────────────
+
+      - name: 🔍 Classify intent
+        id: classify
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ROUTER_DISCUSSION_NUMBER: ${{ github.event.client_payload.discussion_number || github.event.discussion.number || github.event.inputs.discussion_number }}
+          ROUTER_COMMENT_BODY: ${{ github.event.client_payload.comment_body || github.event.comment.body || github.event.discussion.body || github.event.inputs.comment_body || '' }}
+          ROUTER_DISCUSSION_TITLE: ${{ github.event.discussion.title || '' }}
+          ROUTER_CATEGORY_NAME: ${{ github.event.client_payload.category_name || github.event.discussion.category.name || github.event.inputs.category_name || '' }}
+          ROUTER_EVENT_TYPE: ${{ github.event.client_payload.event_type || github.event_name || '' }}
+        run: |
+          INTENT=$(python scripts/router.py \
+            --classify-only \
+            --discussion-number "${ROUTER_DISCUSSION_NUMBER}" \
+            --comment-body "${ROUTER_COMMENT_BODY}" \
+            --discussion-title "${ROUTER_DISCUSSION_TITLE}" \
+            --category-name "${ROUTER_CATEGORY_NAME}" \
+            --event-type "${ROUTER_EVENT_TYPE}")
+          echo "result=${INTENT}" >> "$GITHUB_OUTPUT"
+          echo "Intent: ${INTENT}"
+
+      # ════════════════════════════════════════════════════════════════════
+      #  JOIN 分支 — 条件检测 + 邀请发送（轻量，无 RAG）
+      # ════════════════════════════════════════════════════════════════════
+
+      - name: 🤝 JOIN — 条件检测 + 邀请
+        if: steps.classify.outputs.result == 'JOIN'
+        env:
+          CSM_QA_GH_TOKEN: ${{ secrets.CSM_QA_GH_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DISCUSSION_SOURCE_REPO: ${{ github.repository_owner }}/.github
+          JOIN_FOLLOW_ORG: ${{ vars.JOIN_FOLLOW_ORG || 'NEVSTOP-LAB' }}
+          JOIN_STAR_REPOS: ${{ vars.JOIN_STAR_REPOS || 'Communicable-State-Machine,CSM-API-String-Arguments-Support,CSM-MassData-Parameter-Support,CSM-INI-Static-Variable-Support' }}
+          ROUTER_DISCUSSION_NUMBER: ${{ github.event.client_payload.discussion_number || github.event.discussion.number || github.event.inputs.discussion_number }}
+          ROUTER_COMMENT_AUTHOR: ${{ github.event.client_payload.comment_author || github.event.comment.user.login || github.event.discussion.user.login || github.event.inputs.comment_author || '' }}
+        run: |
+          python scripts/router.py \
+            --intent JOIN \
+            --discussion-number "${ROUTER_DISCUSSION_NUMBER}" \
+            --comment-author "${ROUTER_COMMENT_AUTHOR}" \
+            ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+
+      # ════════════════════════════════════════════════════════════════════
+      #  QA 分支 — RAG 缓存 + CSM_QA 问答（重路径）
+      # ════════════════════════════════════════════════════════════════════
+
+      # QA 之前才 restore RAG 缓存，JOIN/OTHER 不受影响
 
       - name: Restore HuggingFace models cache
         id: cache-hf
+        if: steps.classify.outputs.result == 'QA'
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/huggingface
@@ -105,10 +157,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-hf-
 
-      # 解析 csm-wiki 远程仓库当前 HEAD commit SHA，用于 vector store 缓存 key。
-      # 必须在 cache/restore 之前执行，否则 cache key 会与实际 wiki 内容脱节。
       - name: Resolve csm-wiki latest commit SHA
         id: wiki-sha
+        if: steps.classify.outputs.result == 'QA'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -131,6 +182,7 @@ jobs:
 
       - name: Restore vector store cache
         id: cache-vs
+        if: steps.classify.outputs.result == 'QA'
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -141,39 +193,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vectorstore-
 
-      - name: Run tests
-        run: python -m pytest tests/test_router.py -v
-
-      - name: Route & Process
+      - name: 💬 QA — RAG 问答
+        if: steps.classify.outputs.result == 'QA'
         env:
           CSM_QA_GH_TOKEN: ${{ secrets.CSM_QA_GH_TOKEN }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           DISCUSSION_SOURCE_REPO: ${{ github.repository_owner }}/.github
-          JOIN_FOLLOW_ORG: ${{ vars.JOIN_FOLLOW_ORG || 'NEVSTOP-LAB' }}
-          JOIN_STAR_REPOS: ${{ vars.JOIN_STAR_REPOS || 'Communicable-State-Machine,CSM-API-String-Arguments-Support,CSM-MassData-Parameter-Support,CSM-INI-Static-Variable-Support' }}
           ROUTER_DISCUSSION_NUMBER: ${{ github.event.client_payload.discussion_number || github.event.discussion.number || github.event.inputs.discussion_number }}
-          ROUTER_COMMENT_BODY: ${{ github.event.client_payload.comment_body || github.event.comment.body || github.event.discussion.body || github.event.inputs.comment_body || '' }}
-          ROUTER_DISCUSSION_TITLE: ${{ github.event.discussion.title || '' }}
-          ROUTER_COMMENT_AUTHOR: ${{ github.event.client_payload.comment_author || github.event.comment.user.login || github.event.discussion.user.login || github.event.inputs.comment_author || '' }}
           ROUTER_CATEGORY_NAME: ${{ github.event.client_payload.category_name || github.event.discussion.category.name || github.event.inputs.category_name || '' }}
-          ROUTER_EVENT_TYPE: ${{ github.event.client_payload.event_type || github.event_name || '' }}
         run: |
           python scripts/router.py \
+            --intent QA \
             --discussion-number "${ROUTER_DISCUSSION_NUMBER}" \
-            --comment-body "${ROUTER_COMMENT_BODY}" \
-            --discussion-title "${ROUTER_DISCUSSION_TITLE}" \
-            --comment-author "${ROUTER_COMMENT_AUTHOR}" \
             --category-name "${ROUTER_CATEGORY_NAME}" \
-            --event-type "${ROUTER_EVENT_TYPE}" \
             ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
 
-      # ── 保存 RAG 缓存（在 QA 路径执行后）─────────────────────────────
-      # 即使 Route & Process 步骤失败（如 LLM 超时），也应保存已下载的模型和已构建的向量库。
+      # QA 之后才保存 RAG 缓存
 
       - name: Check HuggingFace cache populated
         id: check-hf-populated
-        if: always() && steps.cache-hf.outputs.cache-hit != 'true'
+        if: always() && steps.classify.outputs.result == 'QA' && steps.cache-hf.outputs.cache-hit != 'true'
         run: |
           if [ -d "$HOME/.cache/huggingface" ] && [ -n "$(ls -A "$HOME/.cache/huggingface" 2>/dev/null)" ]; then
             echo "populated=true" >> "$GITHUB_OUTPUT"
@@ -183,7 +223,7 @@ jobs:
           fi
 
       - name: Save HuggingFace models cache
-        if: always() && steps.cache-hf.outputs.cache-hit != 'true' && steps.check-hf-populated.outputs.populated == 'true'
+        if: always() && steps.classify.outputs.result == 'QA' && steps.cache-hf.outputs.cache-hit != 'true' && steps.check-hf-populated.outputs.populated == 'true'
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/huggingface
@@ -191,7 +231,7 @@ jobs:
 
       - name: Check vector store cache populated
         id: check-vs-populated
-        if: always() && steps.cache-vs.outputs.cache-hit != 'true'
+        if: always() && steps.classify.outputs.result == 'QA' && steps.cache-vs.outputs.cache-hit != 'true'
         run: |
           if [ -d ".csm_llm_qa/vector_store" ] && [ -n "$(ls -A .csm_llm_qa/vector_store 2>/dev/null)" ]; then
             echo "populated=true" >> "$GITHUB_OUTPUT"
@@ -201,7 +241,7 @@ jobs:
           fi
 
       - name: Save vector store cache
-        if: always() && steps.cache-vs.outputs.cache-hit != 'true' && steps.check-vs-populated.outputs.populated == 'true'
+        if: always() && steps.classify.outputs.result == 'QA' && steps.cache-vs.outputs.cache-hit != 'true' && steps.check-vs-populated.outputs.populated == 'true'
         uses: actions/cache/save@v4
         with:
           path: |
@@ -209,3 +249,20 @@ jobs:
             csm-wiki/wiki_source.json
             csm-wiki/remote
           key: ${{ steps.cache-vs.outputs.cache-primary-key }}
+
+      # ════════════════════════════════════════════════════════════════════
+      #  OTHER 分支 — 友好引导（轻量）
+      # ════════════════════════════════════════════════════════════════════
+
+      - name: 💡 OTHER — 友好引导
+        if: steps.classify.outputs.result == 'OTHER'
+        env:
+          CSM_QA_GH_TOKEN: ${{ secrets.CSM_QA_GH_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DISCUSSION_SOURCE_REPO: ${{ github.repository_owner }}/.github
+          ROUTER_DISCUSSION_NUMBER: ${{ github.event.client_payload.discussion_number || github.event.discussion.number || github.event.inputs.discussion_number }}
+        run: |
+          python scripts/router.py \
+            --intent OTHER \
+            --discussion-number "${ROUTER_DISCUSSION_NUMBER}" \
+            ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}

--- a/scripts/router.py
+++ b/scripts/router.py
@@ -83,8 +83,7 @@ LLM_MODEL = os.getenv("LLM_MODEL", "deepseek-chat")
 # QA 分类名（大小写精确匹配）
 QA_CATEGORY_NAME = "Q&A"
 
-# 降级正则
-_RE_JOIN = re.compile(r"加入|申请加入|成为成员|想加入|申请成为|参与贡献|join", re.IGNORECASE)
+# 降级正则：JOIN 匹配在 _fallback_classify 内按强弱分层
 _RE_QA = re.compile(r"问|？|\?|怎么|如何|是什么|报错|bug|error|请教|求助", re.IGNORECASE)
 
 # ── GQL 客户端 ──────────────────────────────────────────────────────────────
@@ -162,9 +161,11 @@ def _rest_req(token: str, method: str, path: str) -> Any:
 def classify_intent(comment_body: str) -> str:
     """对评论正文做 LLM 三分类，返回 ``"JOIN"`` / ``"QA"`` / ``"OTHER"``。
 
-    失败时降级为正则匹配：
-    - 含 join/加入/申请/apply → JOIN
-    - 含问号/怎么/如何等 → QA
+    失败时降级为正则匹配（强弱分层）：
+    - 强关键词（加入/申请加入/成为成员/想加入/参与贡献）→ JOIN
+    - 弱关键词 join + QA 模式共存（如 "怎么 join 数组"）→ QA
+    - 仅弱关键词 join → JOIN
+    - QA 关键词 → QA
     - 其余 → OTHER
     """
     text = comment_body.strip()
@@ -212,12 +213,29 @@ def classify_intent(comment_body: str) -> str:
 
 
 def _fallback_classify(text: str) -> str:
-    if _RE_JOIN.search(text):
-        logger.info("正则降级分类: JOIN")
+    # 强 JOIN 模式（中文明确表达加入意图）
+    _RE_JOIN_STRONG = re.compile(r"加入|申请加入|成为成员|想加入|申请成为|参与贡献", re.IGNORECASE)
+    has_strong_join = _RE_JOIN_STRONG.search(text)
+    has_qa = _RE_QA.search(text)
+    has_weak_join = re.search(r"\bjoin\b", text, re.IGNORECASE) if not has_strong_join else None
+
+    if has_strong_join:
+        logger.info("正则降级分类: JOIN（强关键词）")
         return "JOIN"
-    if _RE_QA.search(text):
+
+    if has_qa and has_weak_join:
+        # "LabVIEW 怎么 join 数组" → QA 优先于弱 join
+        logger.info("正则降级分类: QA（弱 join + QA 模式共存）")
+        return "QA"
+
+    if has_weak_join:
+        logger.info("正则降级分类: JOIN（弱 join）")
+        return "JOIN"
+
+    if has_qa:
         logger.info("正则降级分类: QA")
         return "QA"
+
     logger.info("正则降级分类: OTHER")
     return "OTHER"
 

--- a/scripts/router.py
+++ b/scripts/router.py
@@ -739,6 +739,19 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         default="",
         help="GitHub 事件类型（discussion / discussion_comment）",
     )
+    parser.add_argument(
+        "--classify-only",
+        action="store_true",
+        default=False,
+        help="仅分类并输出意图，不执行任何操作",
+    )
+    parser.add_argument(
+        "--intent",
+        type=str,
+        default="",
+        choices=["JOIN", "QA", "OTHER"],
+        help="跳过 LLM 分类，直接使用指定意图处理",
+    )
     return parser.parse_args(argv)
 
 
@@ -759,34 +772,46 @@ def main(argv: Optional[list[str]] = None) -> int:
         args.dry_run,
     )
 
+    # ── 解析意图 ─────────────────────────────────────────────────────────
+
     # 1. 构造分类输入：discussion 事件将标题拼入正文（标题承载主要意图）
     classify_input = args.comment_body
     if args.event_type == "discussion" and args.discussion_title.strip():
         classify_input = f"{args.discussion_title.strip()}\n\n{args.comment_body}".strip()
 
-    intent = classify_intent(classify_input)
-    logger.info("意图分类: %s", intent)
+    # 2. 获取意图（--intent 跳过 LLM）
+    if args.intent:
+        intent = args.intent
+        logger.info("意图（手动指定）: %s", intent)
+    else:
+        intent = classify_intent(classify_input)
+        logger.info("意图分类: %s", intent)
 
-    # 1b. Q&A 分类的 discussion.created：正文短 → 直接按 QA 处理
-    if (
-        args.event_type == "discussion"
-        and intent == "OTHER"
-        and args.category_name == QA_CATEGORY_NAME
-        and len(args.comment_body.strip()) <= 20
-    ):
-        logger.info("短正文 + Q&A 分类 + discussion.created → 按 QA 处理")
-        intent = "QA"
-
-    # 1c. 空评论的特殊处理：discussion.created 事件无评论、但正文可能是 QA
-    if not classify_input.strip() and args.event_type == "discussion":
-        if args.category_name == QA_CATEGORY_NAME:
-            logger.info("空内容 + Q&A 分类 + discussion.created → 按 QA 处理")
+        # 2b. Q&A 分类的 discussion.created：正文短 → 直接按 QA 处理
+        if (
+            args.event_type == "discussion"
+            and intent == "OTHER"
+            and args.category_name == QA_CATEGORY_NAME
+            and len(args.comment_body.strip()) <= 20
+        ):
+            logger.info("短正文 + Q&A 分类 + discussion.created → 按 QA 处理")
             intent = "QA"
-        else:
-            logger.info("空内容 + 非 Q&A + discussion.created → 跳过（不回复）")
-            return 0
 
-    # 2. 按意图分派
+        # 2c. 空评论的特殊处理
+        if not classify_input.strip() and args.event_type == "discussion":
+            if args.category_name == QA_CATEGORY_NAME:
+                logger.info("空内容 + Q&A 分类 + discussion.created → 按 QA 处理")
+                intent = "QA"
+            else:
+                logger.info("空内容 + 非 Q&A + discussion.created → 跳过（不回复）")
+                return 0
+
+    # 3. --classify-only：仅输出意图供 workflow 捕获
+    if args.classify_only:
+        print(intent)
+        return 0
+
+    # ── 按意图分派 ───────────────────────────────────────────────────────
     if intent == "JOIN":
         _handle_join(token, args.discussion_number, args.comment_author, args.dry_run)
     elif intent == "QA":

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -66,7 +66,7 @@ class TestClassifyIntent:
 
     def test_no_api_key_falls_back(self, monkeypatch):
         monkeypatch.setattr("scripts.router.LLM_API_KEY", "")
-        assert classify_intent("/join") == "JOIN"
+        assert classify_intent("想加入") == "JOIN"
         assert classify_intent("怎么用？") == "QA"
         assert classify_intent("hello") == "OTHER"
 
@@ -94,7 +94,7 @@ class TestBuildConditionReport:
         ]
         report = build_condition_report("testuser", False, results)
         assert "当前 1/2 项通过" in report
-        assert "再次发送 `/join`" in report
+        assert "请再次发送申请" in report
         assert "✅" in report
         assert "❌" in report
 
@@ -105,7 +105,7 @@ class TestBuildConditionReport:
         ]
         report = build_condition_report("testuser", False, results)
         assert "当前 0/2 项通过" in report
-        assert "再次发送 `/join`" in report
+        assert "请再次发送申请" in report
 
     def test_star_repo_list_in_report(self):
         results = [


### PR DESCRIPTION
## 变更

### 1. 降级正则强弱分层
旧逻辑 JOIN 正则先匹配，`join` 太宽误判 "LabVIEW 怎么 join 数组" 为 JOIN。
新逻辑：
- 强 JOIN 关键词（加入/申请加入/成为成员/想加入/参与贡献）→ 优先 JOIN
- 弱 `join` + QA 共存 → QA 优先（技术上下文）
- 仅弱 `join` → JOIN（英文兜底）
- 修复 3 个测试：`/join` → `想加入`，`再次发送 /join` → `请再次发送申请`

### 2. Workflow 按意图分支化
`org-router.yml` 重构为三个独立步骤，Actions UI 中清楚可见当前路径：

```
🔍 Classify intent → 输出 result=JOIN|QA|OTHER
  ├── 🤝 JOIN — 条件检测 + 邀请       [无 RAG 缓存，秒级]
  ├── 💬 QA   — HF+VS 缓存 + RAG 问答  [缓存仅在 QA 分支 restore/save]
  └── 💡 OTHER — 友好引导              [无 RAG 缓存，秒级]
```

- router.py 新增 `--classify-only`（仅输出意图）和 `--intent`（跳过 LLM 直接执行）
- HF 模型 + Vector Store 缓存 `if` 条件更新为 `steps.classify.outputs.result == 'QA'`
- JOIN/OTHER 路径完全不接触 RAG 缓存