### PR TITLE
fix: remove unsupported orderBy arg from Discussion.comments GraphQL query

### DIFF
--- a/scripts/router.py
+++ b/scripts/router.py
@@ -833,7 +833,7 @@ def fetch_discussion(
             id
             name
           }
-          comments(first: 100, orderBy: { field: CREATED_AT, direction: ASC }) {
+          comments(first: 100) {
             nodes {
               id
               body
@@ -862,7 +862,7 @@ def fetch_discussion(
         query($discussionId: ID!, $cursor: String!) {
           node(id: $discussionId) {
             ... on Discussion {
-              comments(first: 100, after: $cursor, orderBy: { field: CREATED_AT, direction: ASC }) {
+              comments(first: 100, after: $cursor) {
                 nodes {
                   id
                   body


### PR DESCRIPTION
## 问题

GitHub Actions workflow `org-router.yml` 在 JOIN 分支执行时崩溃：

```
RuntimeError: GitHub GraphQL errors: Field 'comments' doesn't accept argument 'orderBy'
```

根因: GitHub GraphQL API 的 `Discussion.comments` 字段不支持 `orderBy` 参数。

## 修改

移除 `fetch_discussion()` 中两个 GraphQL 查询的 `orderBy: { field: CREATED_AT, direction: ASC }` 参数:

| 位置 | 修改 |
|------|------|
| `router.py:836` (初始查询) | `comments(first: 100)` |
| `router.py:865` (分页查询) | `comments(first: 100, after: $cursor)` |

GitHub API 默认评论排序即为按创建时间升序（最旧优先），与原先显式指定的排序一致，无行为回归。

## 测试

```
pytest tests/test_router.py -v  # 42 passed
```