### PR TITLE
feat: 脚本支持 --marker-start/--marker-end 参数，区域名称可配置

### DIFF
--- a/scripts/update_csm_modsets.py
+++ b/scripts/update_csm_modsets.py
@@ -19,6 +19,7 @@ Environment variables:
 
 from __future__ import annotations
 
+import argparse
 import html
 import os
 import re
@@ -29,14 +30,19 @@ from datetime import datetime, timezone
 
 import requests
 
-from scripts._utils import api_headers
+# ── 确保包根目录在 sys.path（直接运行 scripts/ 时使用）──────────────────────
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts._utils import api_headers  # noqa: E402
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 GITHUB_API = "https://api.github.com"
 TOPIC = "csm-modsets"
 MAX_PER_OWNER_IN_README = 5
-README_MARKER_START = "<!-- CSM_MODSETS_START -->"
-README_MARKER_END = "<!-- CSM_MODSETS_END -->"
+DEFAULT_MARKER_START = "<!-- CSM_MODSETS_START -->"
+DEFAULT_MARKER_END = "<!-- CSM_MODSETS_END -->"
 
 
 # ── GitHub API helpers ─────────────────────────────────────────────────────────
@@ -222,8 +228,14 @@ def generate_readme_pre_content(
 
 # ── File updaters ──────────────────────────────────────────────────────────────
 
-def update_readme(readme_path: str, pre_content: str) -> bool:
-    """Replace the CSM_MODSETS marker block in *readme_path*.
+def update_readme(
+    readme_path: str,
+    pre_content: str,
+    *,
+    marker_start: str = DEFAULT_MARKER_START,
+    marker_end: str = DEFAULT_MARKER_END,
+) -> bool:
+    """Replace the *marker_start* / *marker_end* block in *readme_path*.
 
     If the markers are absent the block is appended before any trailing HTML
     comment.  Returns True when the file was actually changed.
@@ -232,13 +244,13 @@ def update_readme(readme_path: str, pre_content: str) -> bool:
         content = fh.read()
 
     new_block = (
-        f"{README_MARKER_START}\n"
+        f"{marker_start}\n"
         f"<pre>\n{pre_content}\n</pre>\n"
-        f"{README_MARKER_END}"
+        f"{marker_end}"
     )
 
     pattern = re.compile(
-        re.escape(README_MARKER_START) + r".*?" + re.escape(README_MARKER_END),
+        re.escape(marker_start) + r".*?" + re.escape(marker_end),
         re.DOTALL,
     )
 
@@ -277,8 +289,24 @@ def write_csm_modsets_md(path: str, content: str) -> bool:
 # ── Entry point ────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
-    readme_path = sys.argv[1] if len(sys.argv) > 1 else "profile/README.md"
-    modsets_md_path = sys.argv[2] if len(sys.argv) > 2 else "csm-modsets.md"
+    parser = argparse.ArgumentParser(description="Update CSM modsets listings")
+    parser.add_argument(
+        "readme_path", nargs="?", default="profile/README.md",
+        help="Path to profile/README.md (default: %(default)s)",
+    )
+    parser.add_argument(
+        "modsets_md_path", nargs="?", default="csm-modsets.md",
+        help="Path to csm-modsets.md (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--marker-start", default=DEFAULT_MARKER_START,
+        help="HTML comment marking the start of the editable region (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--marker-end", default=DEFAULT_MARKER_END,
+        help="HTML comment marking the end of the editable region (default: %(default)s)",
+    )
+    args = parser.parse_args()
 
     print(f"Fetching public repos with topic '{TOPIC}' from GitHub …")
     repos = fetch_repos_with_topic(TOPIC)
@@ -291,15 +319,19 @@ if __name__ == "__main__":
     updated_at = now.strftime("%Y-%m-%d %H:%M UTC")
 
     # ── Update csm-modsets.md ────────────────────────────────────────────────
-    print(f"\nUpdating {modsets_md_path} …")
+    print(f"\nUpdating {args.modsets_md_path} …")
     modsets_content = generate_csm_modsets_md(groups, updated_at)
-    changed = write_csm_modsets_md(modsets_md_path, modsets_content)
+    changed = write_csm_modsets_md(args.modsets_md_path, modsets_content)
     print("  Updated." if changed else "  No changes.")
 
     # ── Update profile/README.md ─────────────────────────────────────────────
-    print(f"\nUpdating {readme_path} …")
-    pre_content = generate_readme_pre_content(groups, modsets_md_path)
-    changed = update_readme(readme_path, pre_content)
+    print(f"\nUpdating {args.readme_path} …")
+    pre_content = generate_readme_pre_content(groups, args.modsets_md_path)
+    changed = update_readme(
+        args.readme_path, pre_content,
+        marker_start=args.marker_start,
+        marker_end=args.marker_end,
+    )
     print("  Updated." if changed else "  No changes.")
 
     print("\nDone.")

--- a/scripts/update_sorted_tags.py
+++ b/scripts/update_sorted_tags.py
@@ -14,22 +14,27 @@ Logic:
 
 from __future__ import annotations
 
+import argparse
 import os
-import re
 import sys
 from collections import Counter
 from urllib.parse import quote
 
-from scripts._utils import api_headers, paginate
+# ── 确保包根目录在 sys.path（直接运行 scripts/ 时使用）──────────────────────
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts._utils import api_headers, paginate  # noqa: E402
 
 ORG = os.environ.get("ORG", "NEVSTOP-LAB")
 OUTPUT_FILE = os.environ.get("OUTPUT_FILE", "profile/README.md")
 MIN_TAG_COUNT = int(os.environ.get("MIN_TAG_COUNT", "1"))
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
 
-# ── Markers ───────────────────────────────────────────────────────────────────
-TAGS_START = "<!-- SORTED_TAGS_START -->"
-TAGS_END = "<!-- SORTED_TAGS_END -->"
+# ── Default markers ───────────────────────────────────────────────────────────
+DEFAULT_MARKER_START = "<!-- SORTED_TAGS_START -->"
+DEFAULT_MARKER_END = "<!-- SORTED_TAGS_END -->"
 
 
 def get_public_repos() -> list[dict]:
@@ -69,8 +74,14 @@ def build_tag_lines(repos: list[dict]) -> list[str]:
     return lines
 
 
-def update_readme(readme_path: str, tag_lines: list[str]) -> bool:
-    """Replace the content between SORTED_TAGS markers with *tag_lines*.
+def update_readme(
+    readme_path: str,
+    tag_lines: list[str],
+    *,
+    marker_start: str = DEFAULT_MARKER_START,
+    marker_end: str = DEFAULT_MARKER_END,
+) -> bool:
+    """Replace the content between *marker_start* / *marker_end* with *tag_lines*.
 
     Returns ``True`` if the file was modified, ``False`` otherwise.
     """
@@ -78,12 +89,14 @@ def update_readme(readme_path: str, tag_lines: list[str]) -> bool:
         content = f.read()
 
     # ── Locate the marker block ───────────────────────────────────────────
-    start_pos = content.find(TAGS_START)
-    end_pos = content.find(TAGS_END)
+    start_pos = content.find(marker_start)
+    end_pos = content.find(marker_end)
     if start_pos == -1 or end_pos == -1 or end_pos <= start_pos:
-        raise ValueError(f"SORTED_TAGS markers not found in {readme_path}")
+        raise ValueError(
+            f"Markers {marker_start!r} / {marker_end!r} not found in {readme_path}"
+        )
 
-    before = content[:start_pos + len(TAGS_START)]
+    before = content[:start_pos + len(marker_start)]
     after = content[end_pos:]
 
     body = "\n".join(tag_lines)
@@ -97,7 +110,7 @@ def update_readme(readme_path: str, tag_lines: list[str]) -> bool:
     return True
 
 
-def main(output_file: str) -> None:
+def main(output_file: str, *, marker_start: str = DEFAULT_MARKER_START, marker_end: str = DEFAULT_MARKER_END) -> None:
     print(f"Fetching public repositories for org: {ORG}")
     repos = get_public_repos()
     print(f"  Found {len(repos)} public repositories")
@@ -105,7 +118,11 @@ def main(output_file: str) -> None:
     tag_lines = build_tag_lines(repos)
     print(f"  Keeping {len(tag_lines)} tags with count > {MIN_TAG_COUNT}")
 
-    changed = update_readme(output_file, tag_lines)
+    changed = update_readme(
+        output_file, tag_lines,
+        marker_start=marker_start,
+        marker_end=marker_end,
+    )
     if changed:
         print(f"Updated {output_file}")
     else:
@@ -113,5 +130,18 @@ def main(output_file: str) -> None:
 
 
 if __name__ == "__main__":
-    out = sys.argv[1] if len(sys.argv) > 1 else OUTPUT_FILE
-    main(out)
+    parser = argparse.ArgumentParser(description="Update Sorted By Tags in profile/README.md")
+    parser.add_argument(
+        "output_file", nargs="?", default=OUTPUT_FILE,
+        help="Path to profile/README.md (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--marker-start", default=DEFAULT_MARKER_START,
+        help="HTML comment marking the start of the editable region (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--marker-end", default=DEFAULT_MARKER_END,
+        help="HTML comment marking the end of the editable region (default: %(default)s)",
+    )
+    args = parser.parse_args()
+    main(args.output_file, marker_start=args.marker_start, marker_end=args.marker_end)

--- a/scripts/update_vipm_downloads.py
+++ b/scripts/update_vipm_downloads.py
@@ -13,6 +13,8 @@ Logic:
 
 from __future__ import annotations
 
+import argparse
+import os
 import re
 import sys
 import time
@@ -20,11 +22,16 @@ from datetime import datetime
 
 import requests
 
-from scripts._utils import BEIJING_TZ
+# ── 确保包根目录在 sys.path（直接运行 scripts/ 时使用）──────────────────────
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
-# ── Markers ───────────────────────────────────────────────────────────────────
-VIPM_START = "<!-- VIPM_DOWNLOADS_START -->"
-VIPM_END = "<!-- VIPM_DOWNLOADS_END -->"
+from scripts._utils import BEIJING_TZ  # noqa: E402
+
+# ── Default markers ───────────────────────────────────────────────────────────
+DEFAULT_MARKER_START = "<!-- VIPM_DOWNLOADS_START -->"
+DEFAULT_MARKER_END = "<!-- VIPM_DOWNLOADS_END -->"
 
 # ── Package list – order matches x-axis: Core, API String, MassData,
 #    INI-Variable, DAQ-Example, TCP-Example ──────────────────────────────────
@@ -98,8 +105,14 @@ def get_install_count(package_name: str, max_retries: int = 3) -> int:
     raise RuntimeError(f"Failed to fetch count for {package_name}: {last_exc}") from last_exc
 
 
-def update_readme(readme_path: str, counts: list[int]) -> str | None:
-    """Update the mermaid chart within VIPM_DOWNLOADS markers and return the month string.
+def update_readme(
+    readme_path: str,
+    counts: list[int],
+    *,
+    marker_start: str = DEFAULT_MARKER_START,
+    marker_end: str = DEFAULT_MARKER_END,
+) -> str | None:
+    """Update the mermaid chart within *marker_start* / *marker_end* and return the month string.
 
     Returns the current month string (e.g. '2026.04') if the file was updated,
     or ``None`` if the content was already up-to-date and no write was needed.
@@ -110,21 +123,21 @@ def update_readme(readme_path: str, counts: list[int]) -> str | None:
     now = datetime.now(BEIJING_TZ)
     current_month = f"{now.year}.{now.month:02d}"
 
-    # ── Locate the VIPM_DOWNLOADS marker block ────────────────────────────
-    start_pos = content.find(VIPM_START)
-    end_pos = content.find(VIPM_END)
+    # ── Locate the marker block ────────────────────────────────────────
+    start_pos = content.find(marker_start)
+    end_pos = content.find(marker_end)
     if start_pos == -1 or end_pos == -1 or end_pos <= start_pos:
-        raise ValueError(f"VIPM_DOWNLOADS markers not found in {readme_path}")
+        raise ValueError(f"Markers {marker_start!r} / {marker_end!r} not found in {readme_path}")
 
     before = content[:start_pos]
-    block = content[start_pos:end_pos + len(VIPM_END)]
-    after = content[end_pos + len(VIPM_END):]
+    block = content[start_pos:end_pos + len(marker_end)]
+    after = content[end_pos + len(marker_end):]
 
     # ── Locate the xychart-beta mermaid block within the markers ──────────
     mermaid_re = re.compile(r"(```mermaid\n)(.*?)(```)", re.DOTALL)
     mermaid_match = mermaid_re.search(block)
     if not mermaid_match:
-        raise ValueError("Mermaid block not found within VIPM_DOWNLOADS markers")
+        raise ValueError("Mermaid block not found within markers")
 
     chart_prefix = mermaid_match.group(1)   # ```mermaid\n
     chart_content = mermaid_match.group(2)  # body
@@ -185,7 +198,20 @@ def update_readme(readme_path: str, counts: list[int]) -> str | None:
 
 
 if __name__ == "__main__":
-    readme_path = sys.argv[1] if len(sys.argv) > 1 else "profile/README.md"
+    parser = argparse.ArgumentParser(description="Update VIPM download counts in profile/README.md")
+    parser.add_argument(
+        "readme_path", nargs="?", default="profile/README.md",
+        help="Path to profile/README.md (default: profile/README.md)",
+    )
+    parser.add_argument(
+        "--marker-start", default=DEFAULT_MARKER_START,
+        help="HTML comment marking the start of the editable region (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--marker-end", default=DEFAULT_MARKER_END,
+        help="HTML comment marking the end of the editable region (default: %(default)s)",
+    )
+    args = parser.parse_args()
 
     print("Fetching VIPM download counts …")
     counts: list[int] = []
@@ -194,8 +220,12 @@ if __name__ == "__main__":
         print(f"  {pkg}: {count:,}")
         counts.append(count)
 
-    print(f"\nUpdating {readme_path} …")
-    month = update_readme(readme_path, counts)
+    print(f"\nUpdating {args.readme_path} …")
+    month = update_readme(
+        args.readme_path, counts,
+        marker_start=args.marker_start,
+        marker_end=args.marker_end,
+    )
     if month is None:
         print("No changes detected. Skipping update.")
     else:


### PR DESCRIPTION
## 概述

将三个修改 `profile/README.md` 的脚本中的区域标记名称提取为 CLI 参数，当前硬编码值作为默认值。

## 变更

### 三个脚本均新增 `--marker-start` / `--marker-end` 参数

| Script | `--marker-start` 默认值 | `--marker-end` 默认值 |
|--------|--------------------------|------------------------|
| `update_vipm_downloads.py` | `<!-- VIPM_DOWNLOADS_START -->` | `<!-- VIPM_DOWNLOADS_END -->` |
| `update_sorted_tags.py` | `<!-- SORTED_TAGS_START -->` | `<!-- SORTED_TAGS_END -->` |
| `update_csm_modsets.py` | `<!-- CSM_MODSETS_START -->` | `<!-- CSM_MODSETS_END -->` |

### 兼容性

- 所有现有 workflow 调用方式保持不变（positional 参数 + 默认 marker 值）
- 当需要不同标记名称时可通过 `--marker-start` / `--marker-end` 覆盖
- 同时改用 `argparse` 统一 CLI 参数解析，并添加 `sys.path` preamble 确保直接执行时可导入

### 示例

```bash
# 默认行为（不变）
python scripts/update_vipm_downloads.py profile/README.md

# 自定义标记区域
python scripts/update_vipm_downloads.py profile/README.md   --marker-start "<!-- MY_CUSTOM_START -->"   --marker-end "<!-- MY_CUSTOM_END -->"
```

## 验证

- ✅ 全部 104 个测试通过
- ✅ 三个脚本 `--help` 输出正确
- ✅ 默认参数与原有硬编码值完全一致