### PR TITLE
feat: Discussion bot 跳过 SKIP_AUTHORS 评论和讨论

### DIFF
--- a/scripts/discussion_bot.py
+++ b/scripts/discussion_bot.py
@@ -57,6 +57,8 @@ logger = logging.getLogger("discussion_bot")
 QA_CATEGORY_NAME = "Q&A"
 # 追加在 Bot 回复末尾的 HTML 注释，用于防重复检测（用户不可见）
 BOT_MARKER = "<!-- csm-qa-bot -->"
+# 需要跳过的 Discussion 作者登录名集合（不回复这些用户的讨论）
+SKIP_AUTHORS: frozenset[str] = frozenset({"nevstop"})
 # Bot 回复页脚（可见文字）
 BOT_FOOTER = (
     "\n\n---\n"
@@ -246,6 +248,7 @@ def fetch_discussion(
           body
           url
           closed
+          author { login }
           category {
             id
             name
@@ -352,6 +355,9 @@ def compute_reply_plan(
       组装为 ``history``。
     * 否则（已回复且无后续追问）→ 返回 ``None`` 表示无需回复。
 
+    来自 ``SKIP_AUTHORS`` 的评论（如 nevstop）在查找追问和构建历史时会被忽略，
+    如同 Bot 评论一样跳过。
+
     Returns:
         ``(question, history)`` 或 ``None``。``history`` 元素形如
         ``{"role": "user"|"assistant", "content": str}``。
@@ -386,6 +392,7 @@ def compute_reply_plan(
         i
         for i in range(last_bot_idx + 1, len(comments))
         if not _is_bot_comment(comments[i], bot_login)
+        and (comments[i].get("author") or {}).get("login", "") not in SKIP_AUTHORS
     ]
     if not followup_user_indices:
         return None  # 已回复且无追问 → 跳过
@@ -404,6 +411,9 @@ def compute_reply_plan(
     for i in range(latest_followup_idx):
         c_body = (comments[i].get("body") or "").strip()
         if not c_body:
+            continue
+        comment_author = (comments[i].get("author") or {}).get("login", "")
+        if comment_author in SKIP_AUTHORS:
             continue
         is_bot = _is_bot_comment(comments[i], bot_login)
         if is_bot:
@@ -550,6 +560,7 @@ def scan_org_qa_discussions(
             body
             url
             closed
+            author { login }
             category {
               id
               name
@@ -645,6 +656,15 @@ def _process_discussion_dict(
 
     if discussion.get("closed"):
         logger.info("Discussion #%d 已关闭，跳过", number)
+        return False
+
+    author_login = (discussion.get("author") or {}).get("login", "")
+    if author_login in SKIP_AUTHORS:
+        logger.info(
+            "Discussion #%d 作者 %r 在跳过列表中，跳过",
+            number,
+            author_login,
+        )
         return False
 
     plan = compute_reply_plan(discussion, bot_login=bot_login)

--- a/scripts/router.py
+++ b/scripts/router.py
@@ -652,6 +652,7 @@ def _handle_qa(
     logger.info("Q&A 分类下的 QA 请求，初始化 CSM_QA…")
     from scripts.discussion_bot import (  # type: ignore[import-not-found]
         GitHubGraphQL,
+        SKIP_AUTHORS,
         compute_reply_plan,
         build_reply,
         post_comment,
@@ -671,6 +672,14 @@ def _handle_qa(
 
     discussion = fetch_disc(client, source_owner, source_repo, discussion_number)
     disc_id = discussion.get("id", "")
+
+    # 检查 discussion 作者是否在跳过列表中
+    author_login = (discussion.get("author") or {}).get("login", "")
+    if author_login in SKIP_AUTHORS:
+        logger.info(
+            "Discussion #%d 作者 %r 在跳过列表中，跳过", discussion_number, author_login
+        )
+        return
 
     plan = compute_reply_plan(discussion, bot_login)
     if plan is None:

--- a/tests/test_discussion_bot.py
+++ b/tests/test_discussion_bot.py
@@ -16,6 +16,7 @@ if _REPO_ROOT not in sys.path:
 from scripts.discussion_bot import (
     BOT_MARKER,
     BOT_FOOTER,
+    SKIP_AUTHORS,
     build_reply,
     has_bot_replied,
     compute_reply_plan,
@@ -332,6 +333,7 @@ def _make_org_discussion_payload(number: int = 31, comments: list[dict] | None =
                 "body": "Body text",
                 "url": f"https://github.com/NEVSTOP-LAB/.github/discussions/{number}",
                 "closed": False,
+                "author": {"login": "someone"},
                 "category": {"id": "cat2", "name": "Q&A"},
                 "comments": {
                     "nodes": comments or [],
@@ -372,6 +374,7 @@ def test_scan_org_qa_discussions_returns_list():
                         "body": "body1",
                         "url": "https://github.com/NEVSTOP-LAB/.github/discussions/1",
                         "closed": False,
+                        "author": {"login": "someone"},
                         "category": {"id": "cat2", "name": "Q&A"},
                         "comments": {
                             "nodes": [],
@@ -418,6 +421,7 @@ def test_process_discussion_dict_skips_wrong_category():
     disc = {
         "id": "D1", "number": 1, "title": "Q", "body": "",
         "url": "https://github.com/orgs/NEVSTOP-LAB/discussions/1",
+        "author": {"login": "someone"},
         "category": {"id": "other-cat", "name": "General"},
         "comments": {"nodes": []},
     }
@@ -432,6 +436,7 @@ def test_process_discussion_dict_skips_already_replied():
     disc = {
         "id": "D1", "number": 1, "title": "Q", "body": "",
         "url": "https://github.com/orgs/NEVSTOP-LAB/discussions/1",
+        "author": {"login": "someone"},
         "category": {"id": "qa-cat", "name": "Q&A"},
         "comments": {"nodes": [{"id": "c0", "body": f"reply {BOT_MARKER}", "author": {"login": "bot"}}]},
     }
@@ -444,6 +449,48 @@ def test_process_discussion_dict_dry_run_returns_true():
     client = _MockGraphQL({})
     disc = {
         "id": "D1", "number": 1, "title": "How does CSM work?", "body": "",
+        "url": "https://github.com/orgs/NEVSTOP-LAB/discussions/1",
+        "author": {"login": "someone"},
+        "category": {"id": "qa-cat", "name": "Q&A"},
+        "comments": {"nodes": []},
+    }
+    result = _process_discussion_dict(client, _FakeQAEngine(), disc, "qa-cat", dry_run=True)
+    assert result is True
+
+
+def test_process_discussion_dict_skips_nevstop_author():
+    """作者为 nevstop 时应跳过（返回 False）。"""
+    client = _MockGraphQL({})
+    disc = {
+        "id": "D1", "number": 1, "title": "Q", "body": "",
+        "url": "https://github.com/orgs/NEVSTOP-LAB/discussions/1",
+        "author": {"login": "nevstop"},
+        "category": {"id": "qa-cat", "name": "Q&A"},
+        "comments": {"nodes": []},
+    }
+    result = _process_discussion_dict(client, _FakeQAEngine(), disc, "qa-cat", dry_run=True)
+    assert result is False
+
+
+def test_process_discussion_dict_does_not_skip_other_author():
+    """非 nevstop 作者应正常处理。"""
+    client = _MockGraphQL({})
+    disc = {
+        "id": "D1", "number": 1, "title": "Q", "body": "",
+        "url": "https://github.com/orgs/NEVSTOP-LAB/discussions/1",
+        "author": {"login": "other-user"},
+        "category": {"id": "qa-cat", "name": "Q&A"},
+        "comments": {"nodes": []},
+    }
+    result = _process_discussion_dict(client, _FakeQAEngine(), disc, "qa-cat", dry_run=True)
+    assert result is True
+
+
+def test_process_discussion_dict_skips_when_author_missing():
+    """author 字段缺失时不崩溃，也不跳过。"""
+    client = _MockGraphQL({})
+    disc = {
+        "id": "D1", "number": 1, "title": "Q", "body": "",
         "url": "https://github.com/orgs/NEVSTOP-LAB/discussions/1",
         "category": {"id": "qa-cat", "name": "Q&A"},
         "comments": {"nodes": []},
@@ -660,6 +707,63 @@ def test_compute_reply_plan_no_bot_login_treats_clean_thread_as_new_question():
     assert history == []
 
 
+def test_compute_reply_plan_skips_nevstop_followup():
+    """Bot 回复后 nevstop 留言 → 跳过，不将其视为追问（返回 None）。"""
+    disc = {
+        "title": "T", "body": "B",
+        "comments": {
+            "nodes": [
+                _comment(f"答 {BOT_MARKER}", author="bot"),
+                _comment("nevstop 的留言", author="nevstop"),
+            ]
+        },
+    }
+    assert compute_reply_plan(disc, bot_login="bot") is None
+
+
+def test_compute_reply_plan_normal_user_after_nevstop():
+    """nevstop 留言后，普通用户继续追问 → 应回复该用户追问，跳过 nevstop。"""
+    disc = {
+        "title": "T", "body": "B",
+        "comments": {
+            "nodes": [
+                _comment(f"答 {BOT_MARKER}", author="bot"),
+                _comment("nevstop 的留言", author="nevstop"),
+                _comment("用户追问", author="alice"),
+            ]
+        },
+    }
+    plan = compute_reply_plan(disc, bot_login="bot")
+    assert plan is not None
+    question, history = plan
+    assert question == "用户追问"
+    # nevstop 的留言不应出现在 history 中
+    for h in history:
+        assert "nevstop" not in h.get("content", "")
+
+
+def test_compute_reply_plan_nevstop_in_history_is_skipped():
+    """nevstop 留言在 history 中间位置 → 排除该留言，roles 连续正确。"""
+    disc = {
+        "title": "T", "body": "B",
+        "comments": {
+            "nodes": [
+                _comment(f"答1 {BOT_MARKER}", author="bot"),
+                _comment("用户追问1", author="alice"),
+                _comment("nevstop 插话", author="nevstop"),
+                _comment("用户追问2", author="alice"),
+            ]
+        },
+    }
+    plan = compute_reply_plan(disc, bot_login="bot")
+    assert plan is not None
+    question, history = plan
+    assert question == "用户追问2"
+    # history 应不含 nevstop 的留言
+    for h in history:
+        assert "nevstop" not in h.get("content", "")
+
+
 def test_is_bot_comment_fails_closed_without_bot_login():
     """_is_bot_comment 在 bot_login=None 时一律返回 False（不信任 marker）。"""
     from scripts.discussion_bot import _is_bot_comment
@@ -678,6 +782,7 @@ def test_process_discussion_dict_skips_closed():
     disc = {
         "id": "D1", "number": 1, "title": "Q", "body": "",
         "url": "https://github.com/orgs/NEVSTOP-LAB/discussions/1",
+        "author": {"login": "someone"},
         "category": {"id": "qa-cat", "name": "Q&A"},
         "closed": True,
         "comments": {"nodes": []},
@@ -704,6 +809,7 @@ def test_process_discussion_dict_followup_calls_ask_with_history():
     disc = {
         "id": "D1", "number": 1, "title": "T", "body": "B",
         "url": "https://github.com/orgs/NEVSTOP-LAB/discussions/1",
+        "author": {"login": "someone"},
         "category": {"id": "qa-cat", "name": "Q&A"},
         "comments": {
             "nodes": [
@@ -736,6 +842,7 @@ def test_scan_org_qa_discussions_filters_closed():
                     {
                         "id": "D1", "number": 1, "title": "open", "body": "",
                         "url": "u1", "closed": False,
+                        "author": {"login": "someone"},
                         "category": {"id": "cat2", "name": "Q&A"},
                         "comments": {
                             "nodes": [],
@@ -745,6 +852,7 @@ def test_scan_org_qa_discussions_filters_closed():
                     {
                         "id": "D2", "number": 2, "title": "closed", "body": "",
                         "url": "u2", "closed": True,
+                        "author": {"login": "someone"},
                         "category": {"id": "cat2", "name": "Q&A"},
                         "comments": {
                             "nodes": [],


### PR DESCRIPTION
## 概述

修复 [#87](https://github.com/NEVSTOP-LAB/.github/issues/87)：Discussion 机器人现在会跳过 `SKIP_AUTHORS`（当前为 nevstop）的**主动留言**，不再回复。

## 修改列表

### 1. `scripts/discussion_bot.py`
- 新增 `SKIP_AUTHORS` 常量：`frozenset({nevstop})`
- `compute_reply_plan`：搜索追问评论时排除 `SKIP_AUTHORS`，构建 history 时也跳过
- `_process_discussion_dict`：跳过 discussion 作者在 `SKIP_AUTHORS` 中的讨论
- GraphQL 查询补齐 `author { login }` 字段

### 2. `scripts/router.py`
- `_handle_qa`：在调用 `compute_reply_plan` 前检查 discussion 作者，避免 webhook 路径绕过作者跳过逻辑

### 3. `tests/test_discussion_bot.py`
- 新增 6 个测试用例：nevstop 作者跳过、nevstop 追问跳过、普通用户在 nevstop 后追问、nevstop 在 history 中排除、missing author 兼容性等
- 补齐各测试 fixture 的 `author` 字段

## 关键设计决策

- **两级过滤**：discussion 级别（_process_discussion_dict / _handle_qa）→ comment 级别（compute_reply_plan），双重保障
- `SKIP_AUTHORS` 作为 `frozenset`，方便后续扩展
- 防御式访问 `.get("author") or {}` 模式，兼容缺失字段