### PR TITLE
fix: SKIP_AUTHORS 检查统一 .casefold() 以处理 GitHub login 大小写不敏感

### DIFF
--- a/scripts/discussion_bot.py
+++ b/scripts/discussion_bot.py
@@ -57,7 +57,8 @@ logger = logging.getLogger("discussion_bot")
 QA_CATEGORY_NAME = "Q&A"
 # 追加在 Bot 回复末尾的 HTML 注释，用于防重复检测（用户不可见）
 BOT_MARKER = "<!-- csm-qa-bot -->"
-# 需要跳过的 Discussion 作者登录名集合（不回复这些用户的讨论）
+# 需要跳过的 Discussion 作者登录名集合（不回复这些用户的讨论和评论）
+# 注意：GitHub login 大小写不敏感，所有值与比较均应统一 casefold。
 SKIP_AUTHORS: frozenset[str] = frozenset({"nevstop"})
 # Bot 回复页脚（可见文字）
 BOT_FOOTER = (
@@ -392,7 +393,7 @@ def compute_reply_plan(
         i
         for i in range(last_bot_idx + 1, len(comments))
         if not _is_bot_comment(comments[i], bot_login)
-        and (comments[i].get("author") or {}).get("login", "") not in SKIP_AUTHORS
+        and (comments[i].get("author") or {}).get("login", "").casefold() not in SKIP_AUTHORS
     ]
     if not followup_user_indices:
         return None  # 已回复且无追问 → 跳过
@@ -412,7 +413,7 @@ def compute_reply_plan(
         c_body = (comments[i].get("body") or "").strip()
         if not c_body:
             continue
-        comment_author = (comments[i].get("author") or {}).get("login", "")
+        comment_author = (comments[i].get("author") or {}).get("login", "").casefold()
         if comment_author in SKIP_AUTHORS:
             continue
         is_bot = _is_bot_comment(comments[i], bot_login)
@@ -658,7 +659,7 @@ def _process_discussion_dict(
         logger.info("Discussion #%d 已关闭，跳过", number)
         return False
 
-    author_login = (discussion.get("author") or {}).get("login", "")
+    author_login = (discussion.get("author") or {}).get("login", "").casefold()
     if author_login in SKIP_AUTHORS:
         logger.info(
             "Discussion #%d 作者 %r 在跳过列表中，跳过",

--- a/scripts/router.py
+++ b/scripts/router.py
@@ -673,8 +673,8 @@ def _handle_qa(
     discussion = fetch_disc(client, source_owner, source_repo, discussion_number)
     disc_id = discussion.get("id", "")
 
-    # 检查 discussion 作者是否在跳过列表中
-    author_login = (discussion.get("author") or {}).get("login", "")
+    # 检查 discussion 作者是否在跳过列表中（GitHub login 大小写不敏感）
+    author_login = (discussion.get("author") or {}).get("login", "").casefold()
     if author_login in SKIP_AUTHORS:
         logger.info(
             "Discussion #%d 作者 %r 在跳过列表中，跳过", discussion_number, author_login

--- a/tests/test_discussion_bot.py
+++ b/tests/test_discussion_bot.py
@@ -709,6 +709,7 @@ def test_compute_reply_plan_no_bot_login_treats_clean_thread_as_new_question():
 
 def test_compute_reply_plan_skips_nevstop_followup():
     """Bot 回复后 nevstop 留言 → 跳过，不将其视为追问（返回 None）。"""
+    assert "nevstop" in SKIP_AUTHORS  # 验证 SKIP_AUTHORS 配置正确
     disc = {
         "title": "T", "body": "B",
         "comments": {


### PR DESCRIPTION
## 概述

修复 Copilot review 在 #89 中指出的问题：**SKIP_AUTHORS 检查使用区分大小写的比较**，而 GitHub login 大小写不敏感，可能导致跳过逻辑被不同大小写绕过。

#89 已合并，此 PR 补充遗漏的修复。

## 修改

在所有 `SKIP_AUTHORS` 检查位置统一对 login 做 `.casefold()`：

| 位置 | 文件 | 
|------|------|
| `compute_reply_plan` followup 过滤 | `discussion_bot.py` |
| `compute_reply_plan` history 构建 | `discussion_bot.py` |
| `_process_discussion_dict` | `discussion_bot.py` |
| `_handle_qa` | `router.py` |

测试中也添加了 `SKIP_AUTHORS` 引用以消除 unused import 警告。

### 提交
- `5f693fb` (cherry-picked from `fix/copilot-review-casefold`)