### PR TITLE
优化加入申请回复模板 #88

### DIFF
--- a/scripts/router.py
+++ b/scripts/router.py
@@ -501,23 +501,35 @@ def build_condition_report(
     lines.append(
         f"> ⭐ 需 Star 的仓库：{', '.join(_repo_link(r) for r in JOIN_STAR_REPOS)}"
     )
-    lines.append("")
-    lines.append(
-        "\n---\n"
-        "> ### 🏷️ 团队分组说明\n"
-        "> 加入组织后默认邀请至 **CSM-Community**（CSM 社区爱好者）团队，\n"
-        "> 脚本会根据贡献自动提升到对应分组：\n"
-        "> \n"
-        "> | 团队 | 说明 |\n"
-        "> |------|------|\n"
-        "> | **CSM-Community** | CSM 社区爱好者（默认加入） |\n"
-        "> | ├─ **CSM-Module-Author** | CSM 模块的贡献者 |\n"
-        "> |    └─ **CSM-Developer** | CSM 开发人员 |\n"
-        "> \n"
-        "> ---\n"
-        "> ⚠️ **加入后要求**：成员需每月有公开贡献（commit / Issue / PR），"
-        "长期无贡献将被自动移出组织。请保持活跃，为社区做出贡献！"
-    )
+
+    if all_met:
+        lines.append("")
+        lines.append(
+            "\n---\n"
+            "> ### 🏷️ 团队分组说明\n"
+            "> 加入组织后默认邀请至 **CSM-Community**（CSM 社区爱好者）团队。\n"
+            "> \n"
+            "> | 团队 | 说明 |\n"
+            "> |------|------|\n"
+            "> | **CSM-Community** | CSM 社区爱好者（默认加入） |\n"
+            "> | ├─ **CSM-Module-Author** | CSM 模块的贡献者 |\n"
+            "> |    └─ **CSM-Developer** | CSM 开发人员 |\n"
+            "> \n"
+            "> 团队分组权限不会主动提升，@NEVSTOP-LAB/csm-committee 会根据贡献"
+            "提高对应的项目权限。\n"
+            "> \n"
+            "> ---\n"
+            "> ### 💡 温馨提示\n"
+            "> \n"
+            "> - 💬 Q&A 中提问 CSM 相关问题，机器人会自动回复；你也可以创建仓库上传"
+            "你的 CSM 模块，在 Issue 中 @nevstop 或 @NEVSTOP-LAB/csm-committee，"
+            "我们会帮你 Review 并提出改进建议\n"
+            "> - 📋 [项目任务看板](https://github.com/orgs/NEVSTOP-LAB/projects/18) "
+            "中是主要需要完成的任务列表，欢迎认领并完成对应的 Issue\n"
+            "> - ⚠️ 成员需每月有公开贡献（commit / Issue / PR），"
+            "长期无贡献将被自动移出组织。请保持活跃，为社区做出贡献！"
+        )
+
     return "\n".join(lines)
 
 
@@ -925,7 +937,7 @@ def _handle_join(
                 if team_ok:
                     report += (
                         f"\n\n✅ 已邀请加入 **CSM-Community** 团队。"
-                        f"根据后续贡献会自动提升至 CSM-Module-Author / CSM-Developer。"
+                        f"更多权限说明见上方团队分组信息。"
                     )
                 else:
                     report += (

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -119,6 +119,7 @@ class TestBuildConditionReport:
         report = build_condition_report("testuser", False, results)
         assert "当前 0/2 项通过" in report
         assert "请再次发送申请" in report
+        assert "CSM-Community" not in report
 
     def test_star_repo_list_in_report(self):
         results = [

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -88,9 +88,15 @@ class TestBuildConditionReport:
         assert "正在发送邀请" in report
         assert "✅" in report
         assert "❌" not in report
+        # 全部通过时仍包含团队分组信息
         assert "CSM-Community" in report
         assert "CSM-Module-Author" in report
         assert "CSM-Developer" in report
+        # 新增温馨提示
+        assert "温馨提示" in report
+        assert "项目任务看板" in report
+        assert "csm-committee" in report
+        assert "团队分组权限不会主动提升" in report
 
     def test_partial_passed(self):
         results = [
@@ -102,7 +108,8 @@ class TestBuildConditionReport:
         assert "请再次发送申请" in report
         assert "✅" in report
         assert "❌" in report
-        assert "CSM-Community" in report
+        # 未全部通过时不应出现团队分组信息
+        assert "CSM-Community" not in report
 
     def test_none_passed(self):
         results = [


### PR DESCRIPTION
## 概述

修改组织加入申请机器人的回复模板，使信息展示更合理、更友好。

Closes #88

## 修改内容

### 1. `build_condition_report()` 模板优化
- **条件未满足时**：不再显示团队分组说明和「加入后要求」，仅保留条件检测结果和 Star 仓库清单，让申请者聚焦于如何满足条件
- **条件满足后**：新增「💡 温馨提示」列表，包含：
  - Q&A 机器人使用方法与 CSM 模块 Review 流程
  - 项目任务看板链接（Projects/18）
  - 成员活跃度要求
- 团队分组说明更新：明确「权限不会主动提升，由 @NEVSTOP-LAB/csm-committee 根据贡献调整」

### 2. `handle_join()` 团队加入成功消息
- 移除「根据后续贡献会自动提升至...」的表述，改为引用上方团队分组信息，避免与报告内容重复

### 3. 测试更新
- `test_all_passed`：新增温馨提示内容的断言
- `test_partial_passed` / `test_none_passed`：断言未全部通过时不出现团队分组信息

## 关键设计决策
- 团队分组说明和温馨提示仅在条件**全部满足**后展示，避免申请者在条件不满足时被大量信息干扰
- 权限提升机制从「自动」改为「由委员会评估」，与组织实际管理方式一致